### PR TITLE
[READY] - Added ability for divergence script to use env var and dynamic output

### DIFF
--- a/scripts/git_divergence/README.md
+++ b/scripts/git_divergence/README.md
@@ -1,11 +1,59 @@
-# divergence.py
+# Git Divergence
 
-Provides text output comparing master to all upstream unmerged branches
+Python script to outline *stale/outdated unmerged* remote branches in a given Git Repository. Provides an output of said branches, rating them on a scale of how diverged a branch is (sorted by greatest to least).
 
-## Use
+## Usage
 
-python divergence.py
+```
+$ GIT_REPO_PATH=/path/to/git/repository python divergence.py
+```
 
-## DEPENDENCIES
-export GIT_REPO_PATH=/path/to/git/repository OR navigate to the path and execute python /path/to/divergence.py
+### Required Parameters
 
+- `GIT_REPO_PATH`: Path to the repository that will be used by the script. Specified as an env variable.
+    - ex: `GIT_REPO_PATH=/path/to/git/repository python divergence.py`
+
+### Optional Parameters
+
+- `GIT_AUTH_BRANCH`: The name of the authoritative branch in a repository. Specified as an env variable. If not set, defaults to `master`.
+    - ex: `GIT_REPO_PATH=/path/to/git/repository GIT_AUTH_BRANCH=main python divergence.py`
+
+> All parameters can be specified either in-line or using `export`
+
+## Example Output
+
+<details>
+<summary>details</summary>
+
+```
+Repo at /samplerepo successfully loaded.
+Repo description: Unnamed repository; edit this file 'description' to name the repository.
+Remote named "origin" with URL "git@github.com:SampleRepo/Repo.git"
+Branch                                         Behind   Ahead   DSB  DSLC DIVERGENCE
+refs/stash                                      126       2      10    10        0
+0.10.1                                          2879      1     207   207        0
+0.11.1                                          2774      2     192   192        0
+0.12.1                                          2640      2     175   175        0
+0.14.1                                          2337      1     150   150        0
+0.15.0                                          2170      2     140   140        0
+0.16.0                                          1966      1     123   123        0
+0.17.0                                          1845      1     110   110        0
+0.17.3                                          1845      4     110   110        0
+0.18.1                                          1555      1      95    95        0
+0.19.1                                          1362      1      82    82        0
+0.20.1                                          1166      1      67    67        0
+0.21.1                                          942       1      40    40        0
+0.21.2                                          942       2      40    40        0
+0.22.1                                          763       1      40    40        0
+0.23.1                                          419       1      24    24        0
+0.24.0                                          200       3      12    12        0
+0.7.1                                           3259      2     262   262        0
+0.7.2                                           3259      4     262   262        0
+```
+</details>
+
+## Testing
+
+```
+tox
+```

--- a/scripts/git_divergence/divergence.py
+++ b/scripts/git_divergence/divergence.py
@@ -5,7 +5,7 @@ import sys
 
 from git import Repo
 
-MASTER = "master"
+MASTER = os.getenv("GIT_AUTH_BRANCH", default="master")
 
 DATETIME = "%Y-%m-%d %H:%M:%S%z"
 
@@ -52,6 +52,17 @@ def get_divergence_report(repo):
             report.append(row)
 
     return sorted(report, key=lambda k: k["Divergence"], reverse=True)
+
+
+def get_max_len_of_col(repo_list, col_name):
+
+    top_length = 0
+    for _, curr_element in enumerate(repo_list, 0):
+        curr_len = len(curr_element.get(col_name, ""))
+        if curr_len > top_length:
+            top_length = curr_len
+
+    return top_length 
 
 
 def divergence_by_branch(repo, branch):
@@ -111,6 +122,12 @@ def main():
             "GIT_REPO_PATH not set. Export GIT_REPO_PATH=/path/to/git/repository and try again."
         )
         sys.exit(0)
+    if MASTER != "master":
+        print(
+            "GIT_AUTH_BRANCH has been set, using {branch} instead of master...".format(
+                branch=MASTER
+            )
+        )
     try:
         repo = Repo(repo_path)
     except:
@@ -126,7 +143,8 @@ def main():
 
     report = get_divergence_report(repo)
 
-    table = "{:32} {:^8} {:^8} {:^4} {:4} {:8}"
+    branch_name_len = str(get_max_len_of_col(report, "Branch"))
+    table = "{:" + branch_name_len + "} {:^8} {:^8} {:^4} {:4} {:8}"
 
     print(table.format("Branch", "Behind", "Ahead", "DSB", "DSLC", "DIVERGENCE"))
 
@@ -142,9 +160,7 @@ def main():
             )
         )
 
-    return report
-
 
 if __name__ == "__main__":
 
-    report = main()
+    main()

--- a/scripts/git_divergence/setup.py
+++ b/scripts/git_divergence/setup.py
@@ -28,7 +28,7 @@ requirements = [line.strip() for line in open("requirements.txt").readlines()]
 # installing this outside of our repo or shipping
 # to pypi
 setup(
-    version="0.1.0",
+    version="0.2.0",
     name="divergence",
     description="Git Branch Divergence Report",
     long_description=readme,
@@ -38,4 +38,6 @@ setup(
     packages=find_packages(exclude=("tests", "docs")),
     install_requires=requirements,
     cmdclass={"register": DisabledCommands, "upload": DisabledCommands},
+    scripts=['divergence.py'],
+    entry_points={'console_scripts': ['divergence = divergence:main']},
 )


### PR DESCRIPTION
This adds a feature to the `git_divergence` script where one can now specify:
- a different branch than `master` using a env variable, `GIT_AUTH_BRANCH`
- Dynamic size the Branch column in the output, using the longest branch name
- Edited setup.py to allow for this package to be installed properly

## Tests
- [x] Ran locally and installed and ran library

```
$ GIT_REPO_PATH=/orion/ GIT_AUTH_BRANCH=main python3 divergence.py
GIT_AUTH_BRANCH has been set, using main instead of master...
Repo at /orion successfully loaded.
Repo description: Unnamed repository; edit this file 'description' to name the repository.
Remote named "origin" with URL "git@github.com:Nebulaworks/orion.git"
Branch                      Behind   Ahead   DSB  DSLC DIVERGENCE
ms/git_diverge_edit           0        1      0      0        0
origin/ms/git_diverge_edit    0        1      0      0        0
```

```
$ GIT_REPO_PATH=/orion/ GIT_AUTH_BRANCH=main divergence
GIT_AUTH_BRANCH has been set, using main instead of master...
Repo at /orion/ successfully loaded.
Repo description: Unnamed repository; edit this file 'description' to name the repository.
Remote named "origin" with URL "git@github.com:Nebulaworks/orion.git"
Branch                      Behind   Ahead   DSB  DSLC DIVERGENCE
ms/git_diverge_edit           0        1      0      0        0
origin/ms/git_diverge_edit    0        1      0      0        0
```