### PR TITLE
[READY] - [orion-issue-9] - gen_release_notes documentation sets GIT_TOKEN but code requires GITHUB_TOKEN

### DIFF
--- a/scripts/gen_release_notes/README.md
+++ b/scripts/gen_release_notes/README.md
@@ -93,6 +93,8 @@ The following roots are updated, but not `terraform applied`:
 ```
 </details>
 
+NOTE: This script currently only works on GitHub repos.
+
 ## Pre-Requirements
 - Python Version 3.8.X
 

--- a/scripts/gen_release_notes/README.md
+++ b/scripts/gen_release_notes/README.md
@@ -1,6 +1,6 @@
 # gen_release_notes Python Module
 
-This directory contains the python code to generate a `markdown` friendly ChangeLog for a git repository. This changelog takes into account the following elements:
+This directory contains the python code to generate a `markdown` friendly ChangeLog for a GitHub repository. This changelog takes into account the following elements:
 - Changed directories in a given branch (usually a branch that is used in a release)
 - "Smartly" logging all commits and their respective merge PRs based on deployment environment and project
 - Outlining all hotfixes and bugs that came up in said release
@@ -121,7 +121,7 @@ The following roots are updated, but not `terraform applied`:
 $ export CONFIG_LOC="path/to/.gen_release.config"
 
 # This token should have repository read access
-$ export GIT_TOKEN="pat_value" 
+$ export GITHUB_TOKEN="pat_value" 
 ```
 
 3. Invoke the command


### PR DESCRIPTION
Issue: #9 

Fixed typo in instructions for running the script and made it clear that gen_release_notes is currently only able to handle GitHub repos. This is only a docs change and it was tested by loading and viewing the README on my machine.