### PR TITLE
[READY] - [inf-issue515] - term-apply config

### DIFF
--- a/apps/term-apply/main.go
+++ b/apps/term-apply/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -13,41 +12,15 @@ import (
 	"github.com/nebulaworks/orion/apps/term-apply/pkg/version"
 )
 
-func parseEnv() (string, int, string, string) {
-	host, ok := os.LookupEnv("TA_HOST")
-	if !ok {
-		log.Printf("TA_HOST not found, defaulting to '0.0.0.0'")
-		host = "0.0.0.0"
-	}
-	var port int
-	portStr, ok := os.LookupEnv("TA_PORT")
-	port, err := strconv.Atoi(portStr)
-	if !ok || err != nil {
-		log.Printf("bad ports string %s or TA_PORT not found, defaulting to 23234", portStr)
-		port = 23234
-	}
-	uploadDir, ok := os.LookupEnv("TA_UPLOAD_DIR")
-	if !ok {
-		log.Printf("TA_UPLOAD_DIR not found, defaulting to './uploads'")
-		uploadDir = "./uploads"
-	}
-	dataFile, ok := os.LookupEnv("TA_DATAFILE")
-	if !ok {
-		log.Printf("TA_DATAFILE not found, defaulting to 'applicants.csv'")
-		dataFile = "applicants.csv"
-	}
-	return host, port, uploadDir, dataFile
-}
-
 func main() {
 
 	log.Print(version.BuildInfo())
-	host, port, uploadDir, dataFile := parseEnv()
+	config := server.NewConfig()
 
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
-	s, err := server.NewServer(host, uploadDir, dataFile, port)
+	s, err := server.NewServer(config)
 	if err != nil {
 		log.Printf("Cannot create server %v", err)
 	}

--- a/apps/term-apply/pkg/s3file/s3file.go
+++ b/apps/term-apply/pkg/s3file/s3file.go
@@ -12,12 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
-func CopyFromS3(key, filename string) error {
-	bucket, ok := os.LookupEnv("TA_BUCKET")
-	if !ok {
-		log.Printf("TA_BUCKET not defined, %s not written to %s", key, filename)
-		return nil
-	}
+func CopyFromS3(bucket, key, filename string) error {
 	file, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("cannot create %s", filename)
@@ -50,12 +45,7 @@ func CopyFromS3(key, filename string) error {
 	return nil
 }
 
-func CopyToS3(filename, key string) error {
-	bucket, ok := os.LookupEnv("TA_BUCKET")
-	if !ok {
-		log.Printf("TA_BUCKET not defined, %s not written to %s", filename, key)
-		return nil
-	}
+func CopyToS3(bucket, filename, key string) error {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
@@ -87,12 +77,7 @@ func CopyToS3(filename, key string) error {
 	return nil
 }
 
-func S3keyExists(key string) bool {
-	bucket, ok := os.LookupEnv("TA_BUCKET")
-	if !ok {
-		log.Printf("TA_BUCKET not defined, skipping lookup of %s", key)
-		return false
-	}
+func S3keyExists(bucket, key string) bool {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})

--- a/apps/term-apply/pkg/server/config.go
+++ b/apps/term-apply/pkg/server/config.go
@@ -7,10 +7,13 @@ import (
 )
 
 type Config struct {
-	host         string
-	port         int
-	csvTmpFile   string
-	resumeTmpDir string
+	host           string
+	port           int
+	csvTmpFile     string
+	resumeTmpDir   string
+	s3Bucket       string
+	s3CsvPrefix    string
+	s3ResumePrefix string
 }
 
 func NewConfig() Config {
@@ -40,10 +43,31 @@ func NewConfig() Config {
 	}
 	log.Printf("TA_DATAFILE set to '%s'", csvTmpFile)
 
+	s3Bucket, ok := os.LookupEnv("TA_BUCKET")
+	if !ok {
+		s3Bucket = ""
+	}
+	log.Printf("TA_BUCKET set to '%s'", s3Bucket)
+
+	s3CsvPrefix, ok := os.LookupEnv("TA_CSV_PREFIX")
+	if !ok {
+		s3CsvPrefix = "/term-apply/dev/data"
+	}
+	log.Printf("TA_CSV_PREFIX set to '%s'", s3CsvPrefix)
+
+	s3ResumePrefix, ok := os.LookupEnv("TA_RESUME_PREFIX")
+	if !ok {
+		s3ResumePrefix = "/term-apply/dev/resumes"
+	}
+	log.Printf("TA_RESUME_PREFIX set to '%s'", s3ResumePrefix)
+
 	return Config{
-		host:         host,
-		port:         port,
-		csvTmpFile:   csvTmpFile,
-		resumeTmpDir: resumeTmpDir,
+		host:           host,
+		port:           port,
+		csvTmpFile:     csvTmpFile,
+		resumeTmpDir:   resumeTmpDir,
+		s3Bucket:       s3Bucket,
+		s3CsvPrefix:    s3CsvPrefix,
+		s3ResumePrefix: s3ResumePrefix,
 	}
 }

--- a/apps/term-apply/pkg/server/config.go
+++ b/apps/term-apply/pkg/server/config.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+type Config struct {
+	host         string
+	port         int
+	csvTmpFile   string
+	resumeTmpDir string
+}
+
+func NewConfig() Config {
+	host, ok := os.LookupEnv("TA_HOST")
+	if !ok {
+		host = "0.0.0.0"
+	}
+	log.Printf("TA_HOST set to '%s'", host)
+
+	var port int
+	portStr, ok := os.LookupEnv("TA_PORT")
+	port, err := strconv.Atoi(portStr)
+	if !ok || err != nil {
+		port = 23234
+	}
+	log.Printf("TA_PORT set to '%d'", port)
+
+	resumeTmpDir, ok := os.LookupEnv("TA_UPLOAD_DIR")
+	if !ok {
+		resumeTmpDir = "./uploads"
+	}
+	log.Printf("TA_UPLOAD_DIR set to '%s'", resumeTmpDir)
+
+	csvTmpFile, ok := os.LookupEnv("TA_DATAFILE")
+	if !ok {
+		csvTmpFile = "applicants.csv"
+	}
+	log.Printf("TA_DATAFILE set to '%s'", csvTmpFile)
+
+	return Config{
+		host:         host,
+		port:         port,
+		csvTmpFile:   csvTmpFile,
+		resumeTmpDir: resumeTmpDir,
+	}
+}

--- a/apps/term-apply/pkg/server/server.go
+++ b/apps/term-apply/pkg/server/server.go
@@ -24,7 +24,7 @@ type Server struct {
 }
 
 func NewServer(c Config) (*Server, error) {
-	am, err := applicant.NewApplicantManager(c.csvTmpFile, c.resumeTmpDir)
+	am, err := applicant.NewApplicantManager(c.csvTmpFile, c.resumeTmpDir, c.s3Bucket, c.s3ResumePrefix, c.s3CsvPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func NewServer(c Config) (*Server, error) {
 		wish.WithMiddleware(
 			scp.Middleware(
 				transfer.NewNilCopyHandler(),
-				transfer.NewCopyFromClientHandler(c.resumeTmpDir)),
+				transfer.NewCopyFromClientHandler(c.resumeTmpDir, c.s3Bucket, c.s3ResumePrefix)),
 			bubbletea.Middleware(tm.TeaHandler),
 			logging.Middleware(),
 		),


### PR DESCRIPTION
Adds a new server config type to term-apply.

Previous:

- environment variable parsing handled in both main and s3file packages
- hard coded s3 prefixes

New:

- environment variable parsing all handled in one place when creating new config (fixes inf issue 515)
- s3 prefixes can be changed with environment variables (prep-work to address inf issue 525)

Tests:
- [x] locally using live s3