### PR TITLE
[REVIEW] - [inf-issue531] - fix s3 path issue in term-apply

### DIFF
--- a/apps/term-apply/pkg/applicant/manager.go
+++ b/apps/term-apply/pkg/applicant/manager.go
@@ -3,6 +3,7 @@ package applicant
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"reflect"
 	"sync"
 
@@ -18,8 +19,8 @@ type ApplicantManager struct {
 	csvKey     string
 }
 
-func NewApplicantManager(filename, uploadDir, bucket, resumePrefix, csvPrefix string) (*ApplicantManager, error) {
-	if err := openOrCreateFile(filename); err != nil {
+func NewApplicantManager(path, uploadDir, bucket, resumePrefix, csvPrefix string) (*ApplicantManager, error) {
+	if err := openOrCreateFile(path); err != nil {
 		return nil, err
 	}
 	writeChan := make(chan []applicant)
@@ -29,6 +30,7 @@ func NewApplicantManager(filename, uploadDir, bucket, resumePrefix, csvPrefix st
 		return nil, err
 	}
 
+	filename := filepath.Base(path)
 	csvKey := fmt.Sprintf("%s/%s", csvPrefix, filename)
 	am := &ApplicantManager{
 		applicants: []applicant{},
@@ -39,11 +41,11 @@ func NewApplicantManager(filename, uploadDir, bucket, resumePrefix, csvPrefix st
 		csvKey:     csvKey,
 	}
 
-	if err := am.readDataFile(filename); err != nil {
+	if err := am.readDataFile(path); err != nil {
 		return nil, err
 	}
 
-	go am.writeDataFile(filename, writeChan)
+	go am.writeDataFile(path, writeChan)
 
 	return am, nil
 }

--- a/apps/term-apply/pkg/s3file/s3file.go
+++ b/apps/term-apply/pkg/s3file/s3file.go
@@ -94,7 +94,6 @@ func S3keyExists(bucket, key string) bool {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case "NotFound":
-				log.Printf("NotFound")
 				return false
 			default:
 				log.Printf("%v", err)

--- a/apps/term-apply/pkg/s3file/s3file.go
+++ b/apps/term-apply/pkg/s3file/s3file.go
@@ -57,6 +57,7 @@ func CopyToS3(bucket, filename, key string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open file %q, %v", filename, err)
 	}
+	defer content.Close()
 	result, err := uploader.Upload(&s3manager.UploadInput{
 		Body:    content,
 		Bucket:  aws.String(bucket),


### PR DESCRIPTION
Fixes issue where term-apply was writing CSV to PREFIX + FULL_PATH instead of the expected PREFIX + FILE_NAME. Also contains minor unrelated fixes.

Previous:
- The csvKey was being set to the s3 prefix + the full path of the TA_DATAFILE
- When uploading to s3 we never close the local file handle we open
- When a user submitted the form via SSH but hasn't yet uploaded a resume, the logs get spammed with "NotFound" every 5 seconds while they are logged in

New:
- The csvKey is now being set to the filename in TA_DATAFILE and not the full path
- We now close the file handle we open to copy files to S3
- We no longer unnecessarily log "NotFound" every five seconds when a user is connected who has submitted the form via SSH but has not yet SCP'd the resume

Tests:
- [x] locally tested case where `TA_DATAFILE` is set to `/tmp/applicants.csv` and verified CSV was uploaded to the correct prefix in s3
```
2022/05/16 18:49:49 
Build Info:
===========
commit:      8153efb7e246c4bf9e8f1d56e52881703c8fc7c2
build time:  2022-05-16_18:49:47

2022/05/16 18:49:49 TA_HOST set to '0.0.0.0'
2022/05/16 18:49:49 TA_PORT set to '23234'
2022/05/16 18:49:49 TA_UPLOAD_DIR set to './uploads'
2022/05/16 18:49:49 TA_DATAFILE set to '/tmp/applicants.csv'
2022/05/16 18:49:49 TA_BUCKET set to '***REDACTED***'
2022/05/16 18:49:49 TA_CSV_PREFIX set to '/term-apply/dev/data'
2022/05/16 18:49:49 TA_RESUME_PREFIX set to '/term-apply/dev/resumes'
2022/05/16 18:49:49 Starting SSH server on 0.0.0.0:23234
2022/05/16 18:49:55 username: kylerisse attempting to auth with SHA256:JrQZvCtPOx1cwEvzeLKhriwSEWSL8zvZPwj4Ayafhk0
2022/05/16 18:49:55 username: kylerisse not a match: SHA256:wCtqgQxz42I4CcTdJjm3A1mkgeIwG6l58W9dOLJXXVo
2022/05/16 18:49:55 username: kylerisse found match: SHA256:JrQZvCtPOx1cwEvzeLKhriwSEWSL8zvZPwj4Ayafhk0
2022/05/16 18:49:55 kylerisse connect [::1]:49422 true [] xterm-256color 80 24
2022/05/16 18:50:15 Adding new applicant kylerisse with (Carl Smith, carl@realsmith.com, Software Engineer)
2022/05/16 18:50:15 S3 success &{https://***REDACTED***.s3.***REDACTED***.amazonaws.com/term-apply/dev/data/applicants.csv 0xc000216370  0xc0002162f0}
2022/05/16 18:50:25 [::1]:49422 disconnect 29.769093843s
```
- [x] locally verified `NotFound` message is gone
- [x] locally verified no regression added to `CopyToS3` as a result of now closing the file handle