### PR TITLE
[READY] [infra issue 524] term-apply host key consistency

### DIFF
--- a/apps/term-apply/README.md
+++ b/apps/term-apply/README.md
@@ -59,3 +59,5 @@ make test && make build
 | TA_DATAFILE | the csv file name (both locally and in S3) | "applicants.csv" |
 | TA_CSV_PREFIX | the S3 prefix where the `TA_DATAFILE` will be stored | "/term-apply/dev/data" |
 | TA_RESUME_PREFIX | the S3 prefix where the uploaded PDFs will be stored | "/term-apply/dev/resumes" |
+| TA_SSM_HOST_KEY_PARAM | name of the SSM Parameter that holds the ssh host key for the runtime environment. If none is given, a host key is automatically generated | "" |
+| TA_HOST_KEY_PATH | the local path where the ssh host key is located and where it will be generated if no key exists at this location. If an SSM Parameter is provided, this is also the target download location for the stored key. | ".ssh/term_info_ed25519" |

--- a/apps/term-apply/pkg/server/config.go
+++ b/apps/term-apply/pkg/server/config.go
@@ -67,11 +67,12 @@ func NewConfig() Config {
 	if !ok {
 		ssmHostKeyParam = ""
 	}
-
+	log.Printf("TA_SSM_HOST_KEY_PARAM set to '%s'", ssmHostKeyParam)
 	hostKeyPath, ok := os.LookupEnv("TA_HOST_KEY_PATH")
 	if !ok {
 		hostKeyPath = ".ssh/term_info_ed25519"
 	}
+	log.Printf("TA_HOST_KEY_PATH set to '%s'", hostKeyPath)
 
 	return Config{
 		host:            host,

--- a/apps/term-apply/pkg/server/config.go
+++ b/apps/term-apply/pkg/server/config.go
@@ -7,13 +7,15 @@ import (
 )
 
 type Config struct {
-	host           string
-	port           int
-	csvTmpFile     string
-	resumeTmpDir   string
-	s3Bucket       string
-	s3CsvPrefix    string
-	s3ResumePrefix string
+	host            string
+	port            int
+	csvTmpFile      string
+	resumeTmpDir    string
+	s3Bucket        string
+	s3CsvPrefix     string
+	s3ResumePrefix  string
+	ssmHostKeyParam string
+	ssmHostKeyPath  string
 }
 
 func NewConfig() Config {
@@ -61,13 +63,25 @@ func NewConfig() Config {
 	}
 	log.Printf("TA_RESUME_PREFIX set to '%s'", s3ResumePrefix)
 
+	ssmHostKeyParam, ok := os.LookupEnv("TA_SSM_HOST_KEY_PARAM")
+	if !ok {
+		ssmHostKeyParam = ""
+	}
+
+	ssmHostKeyPath, ok := os.LookupEnv("TA_SSM_HOST_KEY_PATH")
+	if !ok {
+		ssmHostKeyPath = ".ssh/term_info_ed25519"
+	}
+
 	return Config{
-		host:           host,
-		port:           port,
-		csvTmpFile:     csvTmpFile,
-		resumeTmpDir:   resumeTmpDir,
-		s3Bucket:       s3Bucket,
-		s3CsvPrefix:    s3CsvPrefix,
-		s3ResumePrefix: s3ResumePrefix,
+		host:            host,
+		port:            port,
+		csvTmpFile:      csvTmpFile,
+		resumeTmpDir:    resumeTmpDir,
+		s3Bucket:        s3Bucket,
+		s3CsvPrefix:     s3CsvPrefix,
+		s3ResumePrefix:  s3ResumePrefix,
+		ssmHostKeyParam: ssmHostKeyParam,
+		ssmHostKeyPath:  ssmHostKeyPath,
 	}
 }

--- a/apps/term-apply/pkg/server/config.go
+++ b/apps/term-apply/pkg/server/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	s3CsvPrefix     string
 	s3ResumePrefix  string
 	ssmHostKeyParam string
-	ssmHostKeyPath  string
+	hostKeyPath     string
 }
 
 func NewConfig() Config {
@@ -68,9 +68,9 @@ func NewConfig() Config {
 		ssmHostKeyParam = ""
 	}
 
-	ssmHostKeyPath, ok := os.LookupEnv("TA_SSM_HOST_KEY_PATH")
+	hostKeyPath, ok := os.LookupEnv("TA_HOST_KEY_PATH")
 	if !ok {
-		ssmHostKeyPath = ".ssh/term_info_ed25519"
+		hostKeyPath = ".ssh/term_info_ed25519"
 	}
 
 	return Config{
@@ -82,6 +82,6 @@ func NewConfig() Config {
 		s3CsvPrefix:     s3CsvPrefix,
 		s3ResumePrefix:  s3ResumePrefix,
 		ssmHostKeyParam: ssmHostKeyParam,
-		ssmHostKeyPath:  ssmHostKeyPath,
+		hostKeyPath:     hostKeyPath,
 	}
 }

--- a/apps/term-apply/pkg/server/server.go
+++ b/apps/term-apply/pkg/server/server.go
@@ -36,6 +36,8 @@ func NewServer(c Config) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		log.Printf("No SSM Parameter given, using local file for SSH Host Key")
 	}
 
 	const SECONDS_FIVE_MINUTES = 300

--- a/apps/term-apply/pkg/server/server.go
+++ b/apps/term-apply/pkg/server/server.go
@@ -32,7 +32,7 @@ func NewServer(c Config) (*Server, error) {
 	tm := ui.NewTeaManager(am)
 
 	if c.ssmHostKeyParam != "" {
-		err = ssmfile.GetParamFromSSM(c.ssmHostKeyParam, c.ssmHostKeyPath)
+		err = ssmfile.GetParamFromSSM(c.ssmHostKeyParam, c.hostKeyPath)
 		if err != nil {
 			return nil, err
 		}
@@ -42,7 +42,7 @@ func NewServer(c Config) (*Server, error) {
 	ws, err := wish.NewServer(
 		ssh.PublicKeyAuth(auth.PkHandler),
 		wish.WithAddress(fmt.Sprintf("%s:%d", c.host, c.port)),
-		wish.WithHostKeyPath(c.ssmHostKeyPath),
+		wish.WithHostKeyPath(c.hostKeyPath),
 		wish.WithMaxTimeout(time.Second*time.Duration(SECONDS_FIVE_MINUTES)),
 		wish.WithMiddleware(
 			scp.Middleware(

--- a/apps/term-apply/pkg/ssmfile/ssmfile.go
+++ b/apps/term-apply/pkg/ssmfile/ssmfile.go
@@ -1,0 +1,48 @@
+package ssmfile
+
+import (
+	"log"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+func GetParamFromSSM(paramName, path string) error {
+	log.Printf("Creating File")
+	file, err := os.Create(path)
+	if err != nil {
+		return err //fmt.Errorf("Cannot create ssh host key file: %s", path)
+	}
+
+	defer file.Close()
+
+	log.Printf("Opening new session")
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Creating SSM Client")
+	ssm_client := ssm.New(sess)
+
+	decrypt := true
+	log.Printf("Getting param: %s", paramName)
+	output, err := ssm_client.GetParameter(&ssm.GetParameterInput{
+		Name:           &paramName,
+		WithDecryption: &decrypt,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Writing to file")
+	_, err = file.WriteString(*output.Parameter.Value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/apps/term-apply/pkg/ssmfile/ssmfile.go
+++ b/apps/term-apply/pkg/ssmfile/ssmfile.go
@@ -10,21 +10,19 @@ import (
 )
 
 func GetParamFromSSM(paramName, path string) error {
-	log.Printf("Searching for Path")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Printf("File %s does not exist... creating", path)
 		dir, _ := filepath.Split(path)
 		os.MkdirAll(dir, 0700)
 	}
 
-	log.Printf("Creating File")
 	file, err := os.Create(path)
 	if err != nil {
-		return err //fmt.Errorf("Cannot create ssh host key file: %s", path)
+		return err
 	}
 
 	defer file.Close()
 
-	log.Printf("Opening new session")
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
@@ -32,11 +30,10 @@ func GetParamFromSSM(paramName, path string) error {
 		return err
 	}
 
-	log.Printf("Creating SSM Client")
 	ssm_client := ssm.New(sess)
 
 	decrypt := true
-	log.Printf("Getting param: %s", paramName)
+	log.Printf("Getting parameter %s from ssm", paramName)
 	output, err := ssm_client.GetParameter(&ssm.GetParameterInput{
 		Name:           &paramName,
 		WithDecryption: &decrypt,
@@ -44,8 +41,6 @@ func GetParamFromSSM(paramName, path string) error {
 	if err != nil {
 		return err
 	}
-
-	log.Printf("Writing to file")
 	_, err = file.WriteString(*output.Parameter.Value)
 	if err != nil {
 		return err

--- a/apps/term-apply/pkg/ssmfile/ssmfile.go
+++ b/apps/term-apply/pkg/ssmfile/ssmfile.go
@@ -3,12 +3,19 @@ package ssmfile
 import (
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
 func GetParamFromSSM(paramName, path string) error {
+	log.Printf("Searching for Path")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		dir, _ := filepath.Split(path)
+		os.MkdirAll(dir, 0700)
+	}
+
 	log.Printf("Creating File")
 	file, err := os.Create(path)
 	if err != nil {

--- a/apps/term-apply/pkg/ssmfile/ssmfile.go
+++ b/apps/term-apply/pkg/ssmfile/ssmfile.go
@@ -10,19 +10,6 @@ import (
 )
 
 func GetParamFromSSM(paramName, path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Printf("File %s does not exist... creating", path)
-		dir, _ := filepath.Split(path)
-		os.MkdirAll(dir, 0700)
-	}
-
-	file, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
@@ -41,6 +28,19 @@ func GetParamFromSSM(paramName, path string) error {
 	if err != nil {
 		return err
 	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Printf("File %s does not exist... creating", path)
+		dir, _ := filepath.Split(path)
+		os.MkdirAll(dir, 0700)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
 	_, err = file.WriteString(*output.Parameter.Value)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Fixes: [infra issue #524](https://gitlab.com/nebulaworks/eng/infra/-/issues/524)

Brief description of the PR

## Previous Behavior
* Each time a new RE of term-apply was spun up, a new SSH host key would be generated, leading to inconsistency of host keys.

## New Behavior
* Host Keys can be downloaded from SSM SecureString Parameters specified by the `TA_SSM_HOST_KEY_PARAM` env variable.
* The location of host keys can be specified by the `TA_HOST_KEY_PATH` env variable.
  * This location serves as the target download location for the key specified by `TA_SSM_HOST_KEY_PARAM` should a parameter be provided, the local location term-apply will look for a preexisting host key, and the location where a host key will generate if none is found at that location.
  * If a new host key is generated, a corresponding public key will also be generated. This public key is not necessary for TA to function and therefore is not downloaded if a parameter is provided

## Tests
1. Started TA with neither new variable set: startup behavior matched the previous behavior exactly
2. Started TA with just `TA_SSM_HOST_KEY_PARAM` set correctly: TA successfully downloaded the host key and started the server without issue. The host key was downloaded to the default location. This worked correctly with and without a preexisting .ssh directory
3. Started TA with just `TA_HOST_KEY_PATH`: TA successfully generated and used a new host key at the specified path
4. Started TA with both new variables set: TA successfully downloaded the host key to the specified location and booted correctly
5. Started TA with `TA_SSM_HOST_KEY_PARAM` set incorrectly: TA failed to start. Any preexisting host keys at the specified location were left intact. If no file existed before, none were created.