### PR TITLE
[READY] [infra 539] term-apply SIGSEGV with public key present but no private key

### DIFF
--- a/apps/term-apply/main.go
+++ b/apps/term-apply/main.go
@@ -22,7 +22,8 @@ func main() {
 
 	s, err := server.NewServer(config)
 	if err != nil {
-		log.Printf("Cannot create server %v", err)
+		log.Printf("Cannot create server %v... exiting", err)
+		os.Exit(1)
 	}
 	s.Start()
 


### PR DESCRIPTION
## Description

Fixes: Infra #539

Brief description of the PR

## Previous Behavior
Fatal error would occur if the `TA_HOST_KEY_PATH` contained a public key with no corresponding private key

## New Behavior
The public key file is deleted and a new key pair is generated

## Tests
* Ran TA with no SSM Param env variable and the standard host key path while having a public key with no corresponding private key
  * TA deleted the unnecessary public key and generated a new key pair in its place
* Ran TA with standard path and no param while having a key pair already at the path
  * TA ran with no error