### PR TITLE
[READY] [infra-529] Remove remnants of term-apply local state tracking

### DIFF
--- a/apps/term-apply/pkg/applicant/lock.go
+++ b/apps/term-apply/pkg/applicant/lock.go
@@ -1,0 +1,19 @@
+package applicant
+
+import "sync"
+
+type LockVendor struct {
+	locks sync.Map
+}
+
+func (self *LockVendor) LockForName(name string) *sync.Mutex {
+	lock, _ := self.locks.LoadOrStore(name, &sync.Mutex{})
+	if lock, ok := lock.(*sync.Mutex); ok {
+		return lock
+	}
+	panic("Failed to store mutex")
+}
+
+func NewLockVendor() *LockVendor {
+	return &LockVendor{}
+}

--- a/apps/term-apply/pkg/applicant/lock_test.go
+++ b/apps/term-apply/pkg/applicant/lock_test.go
@@ -1,0 +1,21 @@
+package applicant
+
+import "testing"
+
+func TestLockForSameKeyIsSame(t *testing.T) {
+	vendor := NewLockVendor()
+	firstTime := vendor.LockForName("testing")
+	secondTime := vendor.LockForName("testing")
+	if firstTime != secondTime {
+		t.Fatal()
+	}
+}
+
+func TestLockForDifferentKeyIsDifferent(t *testing.T) {
+	vendor := NewLockVendor()
+	firstTime := vendor.LockForName("testing")
+	secondTime := vendor.LockForName("different")
+	if firstTime == secondTime {
+		t.Fatal()
+	}
+}

--- a/apps/term-apply/pkg/applicant/manager.go
+++ b/apps/term-apply/pkg/applicant/manager.go
@@ -18,7 +18,6 @@ type ApplicantManager struct {
 	mu            *sync.RWMutex          // wraps applicant slice access
 	writeChan     chan applicationPacket // serializes application uploads
 	resumes       *resumeWatcher
-	bucket        string
 	dynamodbTable string
 	dynamodbIndex string
 }
@@ -29,11 +28,11 @@ type applicationPacket struct {
 	writeState writeState
 }
 
-func NewApplicantManager(uploadDir, bucket, resumePrefix, dynamodbTable, dynamodbIndex string) (*ApplicantManager, error) {
+func NewApplicantManager(bucket, resumePrefix, dynamodbTable, dynamodbIndex string) (*ApplicantManager, error) {
 
 	writeChan := make(chan applicationPacket)
 
-	resumes, err := newResumeWatcher(uploadDir, bucket, resumePrefix)
+	resumes, err := newResumeWatcher(bucket, resumePrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +41,6 @@ func NewApplicantManager(uploadDir, bucket, resumePrefix, dynamodbTable, dynamod
 		mu:            &sync.RWMutex{},
 		writeChan:     writeChan,
 		resumes:       resumes,
-		bucket:        bucket,
 		dynamodbTable: dynamodbTable,
 		dynamodbIndex: dynamodbIndex,
 	}

--- a/apps/term-apply/pkg/applicant/resume.go
+++ b/apps/term-apply/pkg/applicant/resume.go
@@ -2,44 +2,25 @@ package applicant
 
 import (
 	"fmt"
-	"log"
-	"sync"
 
 	"github.com/nebulaworks/orion/apps/term-apply/pkg/s3file"
 )
 
+var checkS3KeyExists = s3file.S3keyExists
+
 type resumeWatcher struct {
-	uploadDir    string
-	uploaded     []string
-	mu           *sync.Mutex
 	bucket       string
 	resumePrefix string
 }
 
-func newResumeWatcher(uploadDir, bucket, resumePrefix string) (*resumeWatcher, error) {
+func newResumeWatcher(bucket, resumePrefix string) (*resumeWatcher, error) {
 	return &resumeWatcher{
-		uploadDir:    uploadDir,
-		uploaded:     []string{},
-		mu:           &sync.Mutex{},
 		bucket:       bucket,
 		resumePrefix: resumePrefix,
 	}, nil
 }
 
 func (r *resumeWatcher) isUploaded(userID string) bool {
-	for _, u := range r.uploaded {
-		if userID == u {
-			return true
-		}
-	}
 	key := fmt.Sprintf("%s/%s-resume.pdf", r.resumePrefix, userID)
-	if s3file.S3keyExists(r.bucket, key) {
-		log.Printf("Didn't find %s in uploaded list, but did find resume file in s3, adding...", userID)
-		r.mu.Lock()
-		defer r.mu.Unlock()
-
-		r.uploaded = append(r.uploaded, userID)
-		return true
-	}
-	return false
+	return checkS3KeyExists(r.bucket, key)
 }

--- a/apps/term-apply/pkg/applicant/resume_test.go
+++ b/apps/term-apply/pkg/applicant/resume_test.go
@@ -1,0 +1,31 @@
+package applicant
+
+import "testing"
+
+func swapS3KeyExists(value func(string, string) bool) {
+	checkS3KeyExists = value
+}
+
+func shouldExist(string, string) bool {
+	return true
+}
+
+func shouldNotExist(string, string) bool {
+	return false
+}
+
+func TestIsUploaded(t *testing.T) {
+	defer swapS3KeyExists(checkS3KeyExists)
+
+	watcher, _ := newResumeWatcher("notarealbucket", "fakeprefix")
+
+	swapS3KeyExists(shouldExist)
+	if !watcher.isUploaded("nothing") {
+		t.Fatalf("It should show as uploaded")
+	}
+
+	swapS3KeyExists(shouldNotExist)
+	if watcher.isUploaded("nothing") {
+		t.Fatalf("It should not show as uploaded")
+	}
+}

--- a/apps/term-apply/pkg/server/server.go
+++ b/apps/term-apply/pkg/server/server.go
@@ -25,7 +25,7 @@ type Server struct {
 }
 
 func NewServer(c Config) (*Server, error) {
-	am, err := applicant.NewApplicantManager(c.resumeTmpDir, c.s3Bucket, c.s3ResumePrefix, c.dynamodbTable, c.dynamodbIndex)
+	am, err := applicant.NewApplicantManager(c.s3Bucket, c.s3ResumePrefix, c.dynamodbTable, c.dynamodbIndex)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This removes the internal applicant-tracking list in the resume module and simply defers to the current state of S3 to answer the question "Has a resume been uploaded?", as well as some associated code that is no longer needed now that we aren't tracking that separately.

This also reworks the locking logic in the manager module. We still had a lock for reading data, but because we're handling writes asynchronously, the lock was getting released before writes occurred. This means the lock was effectively not guarding anything, since both both reading and writing could be done concurrently with a write. Now, we keep a lock per applicant and thread that lock through both the reading and writing process, only unlocking once we're finished with a given transaction.

The actual intended way to handle this with DynamoDB is with extra conditional clauses to perform atomic updates, but doing it that way would cost us our nice programmatic API.